### PR TITLE
OverVue 9.0.0 website

### DIFF
--- a/src/containers/Body.js
+++ b/src/containers/Body.js
@@ -90,7 +90,7 @@ export const Body = () => {
             <img
               alt="Add html element Gif"
               className="shadow"
-              src="../assets/doc-data/WhyPinia.PNG"
+              src="https://i.ibb.co/b2k3vfV/WhyPinia.png"
             />
           </Section>
 
@@ -98,7 +98,7 @@ export const Body = () => {
             <img
               alt="Add html element Gif"
               className="shadow num2"
-              src="../assets/doc-data/js-ts.png"
+              src="https://i.ibb.co/HFJn0gN/js-ts.png"
             />
             <HeadTwoStyle>
               <div className="num1">
@@ -121,7 +121,7 @@ export const Body = () => {
             <img
               alt="Add html element Gif"
               className="shadow"
-              src="../assets/doc-data/NestingHtmlDemo.gif"
+              src="https://media.giphy.com/media/gtsAVD2AQaDZKKnCwz/giphy.gif"
             />
           </Section>
       </SectionContainer>

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -54,7 +54,7 @@ export const Header = () => (
       <br/>
       <Button
         className={"button"}
-        href="https://github.com/open-source-labs/OverVue/releases/download/v9.0.0/OverVue-9.0.0.zip"
+        href="https://github.com/open-source-labs/OverVue/releases/download/v9.0.0/OverVue-9.0.0-linux.zip"
       >
         <div id="download">
           <div>Download for</div> <i className="fab fa-windows" />

--- a/src/containers/Hero.js
+++ b/src/containers/Hero.js
@@ -35,7 +35,7 @@ export const Hero = () => (
       className="subtitle"
     >
       {/* Prototype driven development */}
-      Introducing OverVue 8.0
+      Introducing OverVue 9.0
     </motion.p>
 
     <motion.div
@@ -55,7 +55,7 @@ export const Hero = () => (
 
       <Button
         className={"button"}
-        href="https://github.com/open-source-labs/OverVue/releases/download/v8.0.0/OverVue-8.0.0-darwin-universal.zip"
+        href="https://github.com/open-source-labs/OverVue/releases/download/v9.0.0/OverVue-9.0.0-mac.zip"
       >
         <div id="download">
           <div>Download for </div> <i className="fab fa-apple" />
@@ -64,7 +64,7 @@ export const Hero = () => (
       <br />
       <Button
         className={"button"}
-        href="https://github.com/open-source-labs/OverVue/releases/download/v8.0.0/OverVue-8.0.0-linux-x64.zip"
+        href="https://github.com/open-source-labs/OverVue/releases/download/v9.0.0/OverVue-9.0.0-linux.zip"
       >
         <div id="download">
           <div>Download for Linux</div> <i className="fab fa-brands fa-linux"/>


### PR DESCRIPTION
- Fixed body gif and png urls to links rather than files
- Fixed download links for linux and mac in Hero.js and Header.js